### PR TITLE
fix for undefined oldIndex when using dynamic tabs reset.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-nav-tabs",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "A vue based tab component",
   "repository": {
     "url": "cristijora/vue-tabs",

--- a/src/components/VueTabs.js
+++ b/src/components/VueTabs.js
@@ -69,7 +69,7 @@ export default {
             this.$emit('input', tab.title)
         },
         changeTab (oldIndex, newIndex, route) {
-            let oldTab = this.tabs[oldIndex]
+            let oldTab = this.tabs[oldIndex] || {}
             let newTab = this.tabs[newIndex]
             if (newTab.disabled) return;
             this.activeTabIndex = newIndex


### PR DESCRIPTION
Error in callback for watcher "tabs": "TypeError: Cannot set property 'active' of undefined"

Please merge as I am not expecting to use a forked version.