### PR TITLE
Fix VueTabs.js error where it tries to activate non existent tab

### DIFF
--- a/src/components/VueTabs.js
+++ b/src/components/VueTabs.js
@@ -204,7 +204,7 @@ export default {
         tabs (newList) {
             if (newList.length > 0 && !this.value) {
                 if (newList.length <= this.activeTabIndex) {
-                    this.activateTab(this.activeTabIndex - 1);
+                    this.activateTab(newList.length - 1);
                 } else {
                     this.activateTab(this.activeTabIndex);
                 }


### PR DESCRIPTION
fix issue where new tab list length is less then activeTabIndex for more then 1 which leads to an error as its trying to activate non existent tab