### PR TITLE
Update _bs_nav_tabs.scss

### DIFF
--- a/themes/default/mixins/_bs_nav_tabs.scss
+++ b/themes/default/mixins/_bs_nav_tabs.scss
@@ -4,7 +4,7 @@
 
 @mixin nav-divider($color: #e5e5e5) {
   height: 1px;
-  margin: (($line-height-computed / 2) - 1) 0;
+  margin: (calc($line-height-computed / 2) - 1) 0;
   overflow: hidden;
   background-color: $color;
 }


### PR DESCRIPTION
Update Sass division due to: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.